### PR TITLE
Fix visualizer to handle nodes without timing data

### DIFF
--- a/assets/js/visualizer.js
+++ b/assets/js/visualizer.js
@@ -102,7 +102,16 @@ function processRunResults(data) {
     const results = data.results;
     const generatedAt = data.metadata.generated_at;
 
-    const chartData = results.map(node => {
+    const chartData = results.filter(node => {
+        // Skip nodes without timing data
+        return node.timing && 
+               Array.isArray(node.timing) && 
+               node.timing.length >= 2 &&
+               node.timing[0] && 
+               node.timing[0].started_at &&
+               node.timing[1] && 
+               node.timing[1].completed_at;
+    }).map(node => {
         const compileStart = new Date(node.timing[0].started_at);
         const executeEnd = new Date(node.timing[1].completed_at);
         const runtimeSeconds = (executeEnd - compileStart) / 1000;


### PR DESCRIPTION
## Summary
• Fix runtime errors in DAG visualizer when nodes lack complete timing information
• Add filtering logic to skip nodes without proper timing data structure
• Prevent crashes when processing malformed or incomplete node data

## Test plan
- [x] Test visualizer with sample data containing complete timing information
- [x] Test visualizer with nodes missing timing data (should now be filtered out)
- [x] Verify no runtime errors occur when processing mixed datasets

🤖 Generated with [Claude Code](https://claude.ai/code)