### PR TITLE
Add CLAUDE.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor
 notes.md
 .DS_Store
 _drafts
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Add CLAUDE.md to .gitignore to prevent it from being tracked in version control

## Context
CLAUDE.md is a local documentation file for Claude Code instances working in this repository. It contains guidance about development commands, architecture, and conventions but should remain local-only and not be committed to the repository.

## Test plan
- [x] Verified CLAUDE.md is ignored by git
- [x] Confirmed working tree is clean after adding to .gitignore