### PR TITLE
Add Snowflake Mock Data Generator tool

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,17 +40,18 @@ plugins:
 # Excluded items can be processed by explicitly listing the directories or
 # their entries' file path in the `include:` list.
 #
-# exclude:
-#   - .sass-cache/
-#   - .jekyll-cache/
-#   - gemfiles/
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules/
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
+exclude:
+  - .sass-cache/
+  - .jekyll-cache/
+  - gemfiles/
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  - CLAUDE.md
 
 collections:
   tools:

--- a/_includes/snowflake-generator.html
+++ b/_includes/snowflake-generator.html
@@ -1,0 +1,203 @@
+<div class="snowflake-generator-container">
+    <div class="controls">
+        <div class="control-group">
+            <label for="rowCount">Number of Rows (1-50)</label>
+            <input type="number" id="rowCount" min="1" max="50" value="5">
+            <span class="hint">How many rows of mock data to generate</span>
+        </div>
+
+        <div class="control-group">
+            <label>Column Types</label>
+            <div class="checkbox-group">
+                <div class="checkbox-item">
+                    <input type="checkbox" id="includeName" checked>
+                    <label for="includeName">Name</label>
+                </div>
+                <div class="checkbox-item">
+                    <input type="checkbox" id="includeNameId" checked>
+                    <label for="includeNameId">Name ID</label>
+                </div>
+                <div class="checkbox-item">
+                    <input type="checkbox" id="includeDt" checked>
+                    <label for="includeDt">Date (dt)</label>
+                </div>
+                <div class="checkbox-item">
+                    <input type="checkbox" id="includeMetrics" checked>
+                    <label for="includeMetrics">Metrics</label>
+                </div>
+                <div class="checkbox-item">
+                    <input type="checkbox" id="includeJson" checked>
+                    <label for="includeJson">JSON</label>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="button-group">
+        <button class="btn-primary" onclick="generateQuery()">Generate Query</button>
+        <button class="btn-secondary" onclick="clearOutput()">Clear</button>
+    </div>
+
+    <div class="output-container">
+        <button class="copy-btn" onclick="copyToClipboard()">Copy</button>
+        <textarea id="output" placeholder="Click 'Generate Query' to create mock data..."></textarea>
+    </div>
+</div>
+
+<script src="{{ '/assets/js/snowflake-generator.js' | relative_url }}"></script>
+
+<style>
+.snowflake-generator-container {
+    margin: 20px 0;
+    padding: 20px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    background-color: #fafafa;
+}
+
+.controls {
+    display: grid;
+    gap: 24px;
+    margin-bottom: 24px;
+}
+
+.control-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.control-group label {
+    font-weight: 600;
+    color: #4a5568;
+    font-size: 14px;
+}
+
+.control-group input[type="number"] {
+    padding: 10px 12px;
+    border: 2px solid #e2e8f0;
+    border-radius: 6px;
+    font-size: 14px;
+    transition: border-color 0.2s;
+}
+
+.control-group input[type="number"]:focus {
+    outline: none;
+    border-color: #4CAF50;
+}
+
+.checkbox-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-top: 4px;
+}
+
+.checkbox-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.checkbox-item input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+}
+
+.checkbox-item label {
+    font-weight: 500;
+    cursor: pointer;
+    margin: 0;
+    font-size: 14px;
+}
+
+.button-group {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 24px;
+}
+
+.button-group button {
+    padding: 12px 24px;
+    border: none;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-primary {
+    background-color: #4CAF50;
+    color: white;
+    flex: 1;
+}
+
+.btn-primary:hover {
+    background-color: #45a049;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(76, 175, 80, 0.4);
+}
+
+.btn-secondary {
+    background-color: #e2e8f0;
+    color: #4a5568;
+}
+
+.btn-secondary:hover {
+    background-color: #cbd5e0;
+}
+
+.output-container {
+    position: relative;
+}
+
+.output-container textarea {
+    width: 100%;
+    min-height: 300px;
+    padding: 16px;
+    border: 2px solid #e2e8f0;
+    border-radius: 6px;
+    font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
+    font-size: 13px;
+    line-height: 1.5;
+    resize: vertical;
+}
+
+.output-container textarea:focus {
+    outline: none;
+    border-color: #4CAF50;
+}
+
+.copy-btn {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    padding: 8px 16px;
+    background: white;
+    border: 2px solid #4CAF50;
+    color: #4CAF50;
+    font-size: 12px;
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.copy-btn:hover {
+    background: #4CAF50;
+    color: white;
+}
+
+.copy-btn.copied {
+    background: #48bb78;
+    border-color: #48bb78;
+    color: white;
+}
+
+.hint {
+    color: #718096;
+    font-size: 12px;
+    margin-top: 4px;
+}
+</style>

--- a/_tools/snowflake-mock-generator.md
+++ b/_tools/snowflake-mock-generator.md
@@ -1,0 +1,13 @@
+---
+title: "Mock Data Generator"
+date: 2025-01-07
+description: "Generate a small amount of mock data for testing purposes"
+tags: ["snowflake", "sql", "testing"]
+collection: tools
+emoji: ❄️
+---
+
+This tool generates minimal sql queries with mock data. I often find myself writing queries like this to experiment with a syntax or ambiguous behavior, and figure this might save me some time. The generated queries are ready to copy and paste directly into Snowflake for testing purposes. 
+
+{% include snowflake-generator.html %}
+

--- a/assets/js/snowflake-generator.js
+++ b/assets/js/snowflake-generator.js
@@ -1,0 +1,146 @@
+const characters = [
+    { name: 'Beavis', id: 1 },
+    { name: 'Butthead', id: 2 },
+    { name: 'Daria', id: 3 },
+    { name: 'Mr. Van Driessen', id: 4 },
+    { name: 'Principal McVicker', id: 5 },
+    { name: 'Todd', id: 6 },
+    { name: 'Stewart', id: 7 },
+    { name: 'Coach Buzzcut', id: 8 },
+    { name: 'Tom Anderson', id: 9 }
+];
+
+const actions = [
+    'watching TV',
+    'eating nachos',
+    'laughing at stuff',
+    'breaking things',
+    'being cool',
+    'headbanging',
+    'TP-ing a house',
+    'breaking the law'
+];
+
+function generateQuery() {
+    const rowCount = Math.min(50, Math.max(1, parseInt(document.getElementById('rowCount').value) || 5));
+    const includeName = document.getElementById('includeName').checked;
+    const includeNameId = document.getElementById('includeNameId').checked;
+    const includeDt = document.getElementById('includeDt').checked;
+    const includeMetrics = document.getElementById('includeMetrics').checked;
+    const includeJson = document.getElementById('includeJson').checked;
+
+    let columns = [];
+    let aliases = [];
+
+    if (includeName) {
+        columns.push('name');
+        aliases.push('name');
+    }
+    if (includeNameId) {
+        columns.push('name_id');
+        aliases.push('name_id');
+    }
+    if (includeDt) {
+        columns.push('dt');
+        aliases.push('dt');
+    }
+    if (includeMetrics) {
+        columns.push('metric_1');
+        aliases.push('metric_1');
+        columns.push('metric_2');
+        aliases.push('metric_2');
+    }
+    if (includeJson) {
+        columns.push('metadata');
+        aliases.push('metadata');
+    }
+
+    if (columns.length === 0) {
+        alert('Please select at least one column type');
+        return;
+    }
+
+    // First pass: collect all rows to calculate max widths
+    let rows = [];
+    for (let i = 0; i < rowCount; i++) {
+        const values = [];
+        const char = characters[i % characters.length];
+
+        if (includeName) {
+            values.push(`'${char.name}'`);
+        }
+        if (includeNameId) {
+            values.push(`${char.id}`);
+        }
+        if (includeDt) {
+            const date = new Date(2024, 0, 1);
+            date.setDate(date.getDate() + i);
+            values.push(`'${date.toISOString().split('T')[0]}'`);
+        }
+        if (includeMetrics) {
+            values.push(`${(Math.random() * 100).toFixed(2)}`);
+            values.push(`${Math.floor(Math.random() * 50)}`);
+        }
+        if (includeJson) {
+            const jsonObj = {
+                activity: actions[i % actions.length],
+                is_cool: char.name === 'Beavis' || char.name === 'Butthead',
+                score: Math.floor(Math.random() * 10)
+            };
+            values.push(`parse_json('${JSON.stringify(jsonObj).replace(/'/g, "\\'")}')`);
+        }
+        rows.push(values);
+    }
+
+    // Calculate max width for each column
+    const maxWidths = aliases.map((_, colIdx) => {
+        let maxWidth = aliases[colIdx].length; // Start with alias length
+        rows.forEach(row => {
+            maxWidth = Math.max(maxWidth, row[colIdx].length);
+        });
+        return maxWidth;
+    });
+
+    // Build query with aligned columns
+    let query = 'with mock_data as (\n';
+
+    rows.forEach((values, rowIdx) => {
+        const prefix = rowIdx === 0 ? '  select ' : '  union all select ';
+        const paddedValues = values.map((val, colIdx) => {
+            const padding = ' '.repeat(maxWidths[colIdx] - val.length);
+            return `${val}${padding} as ${aliases[colIdx]}`;
+        });
+        query += `${prefix}${paddedValues.join(', ')}\n`;
+    });
+
+    query += ')\n';
+    query += `select\n  ${columns.join(',\n  ')}\n`;
+    query += 'from mock_data;\n';
+
+    document.getElementById('output').value = query;
+}
+
+function copyToClipboard() {
+    const output = document.getElementById('output');
+    const copyBtn = document.querySelector('.copy-btn');
+
+    output.select();
+    document.execCommand('copy');
+
+    copyBtn.textContent = 'Copied!';
+    copyBtn.classList.add('copied');
+
+    setTimeout(() => {
+        copyBtn.textContent = 'Copy';
+        copyBtn.classList.remove('copied');
+    }, 2000);
+}
+
+function clearOutput() {
+    document.getElementById('output').value = '';
+}
+
+// Generate initial query on page load
+window.addEventListener('DOMContentLoaded', () => {
+    generateQuery();
+});


### PR DESCRIPTION
## Summary

- Added new interactive tool for generating mock SQL data for Snowflake testing
- Created snowflake-generator.js with logic for generating formatted SQL queries
- Added snowflake-generator.html include with UI controls and styling
- Created snowflake-mock-generator.md tool page with proper front matter
- Updated _config.yml to exclude CLAUDE.md from site builds

## Features

The tool allows users to:
- Customize the number of rows (1-50)
- Select different column types (Name, Name ID, Date, Metrics, JSON)
- Generate properly formatted SQL queries with mock data using CTEs
- Copy generated queries to clipboard
- All processing happens client-side

## Test plan

- [x] Jekyll site builds successfully
- [x] Tool page generates at /tools/snowflake-mock-generator/
- [x] JavaScript and CSS are properly included
- [x] CLAUDE.md no longer appears on the site